### PR TITLE
Change the background color of the List-Card

### DIFF
--- a/UhooiPicBook/Modules/MonsterList/Views/MonsterCollectionViewCell.xib
+++ b/UhooiPicBook/Modules/MonsterList/Views/MonsterCollectionViewCell.xib
@@ -33,7 +33,7 @@
                                 </constraints>
                             </imageView>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <color key="backgroundColor" systemColor="secondarySystemGroupedBackgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="iGz-f5-Wgc" firstAttribute="leading" secondItem="WpK-MP-NUF" secondAttribute="leading" constant="16" id="18d-aJ-lC0"/>
                             <constraint firstItem="vOX-iF-1Pu" firstAttribute="centerY" secondItem="WpK-MP-NUF" secondAttribute="centerY" id="3WZ-nq-y52"/>


### PR DESCRIPTION
#21 に関連？
とても細かいところですが、初OSSプルリクエストに挑戦させていただきました…！！
至らぬ点などあったら遠慮なく教えてください🙇‍♂️

## やったこと
ダークモードでリスト画面を表示したところ、カードの色が背景と同化していました。
好みの問題かもしれませんが、ダークモードでもカードの形が分かった方が良いと思い、
ダークモードで表示した時に、背景より少し明るい色になるようにしました。

systemBackgroundColor -> secondarySystemGroupedBackgroundColor

（ `tertiarySystemBackground` でもライトの白は維持したままダークモード時の色をさらに明るくできましたが、文脈的に `secondarySystemGroupedBackgroundColor` が合ってそうだったので選びました🤔）

### 参考
[Dark color cheat sheet](https://sarunw.com/posts/dark-color-cheat-sheet/)

## Preview
### Before
<img src="https://user-images.githubusercontent.com/8737743/89645311-7d0f5c80-d8f4-11ea-9f90-476534eccd77.png" width="200">

### After
左：ライトモード　右：ダークモード
<img src="https://user-images.githubusercontent.com/8737743/89645051-fd818d80-d8f3-11ea-8e65-fdfca955e58f.png" width="200"> <img src="https://user-images.githubusercontent.com/8737743/89645058-007c7e00-d8f4-11ea-8fb7-d50fbeae3aa5.png" width="200">
