### PR TITLE
Implement the foundation for remote push notifications

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,6 +1,7 @@
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseCrashlyticsBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseFirestoreBinary.json"
+binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseMessagingBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebasePerformanceBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseProtobufBinary.json"
 

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,6 @@
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" "6.33.0"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseCrashlyticsBinary.json" "6.33.0"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseFirestoreBinary.json" "6.33.0"
+binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseMessagingBinary.json" "6.33.0"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebasePerformanceBinary.json" "6.33.0"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseProtobufBinary.json" "6.33.0"

--- a/UhooiPicBook/AppDelegate.swift
+++ b/UhooiPicBook/AppDelegate.swift
@@ -62,7 +62,11 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification,
         withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        completionHandler([[.alert, .sound]])
+        if #available(iOS 14.0, *) {
+            completionHandler([[.banner, .list, .sound]])
+        } else {
+            completionHandler([[.alert, .sound]])
+        }
     }
 
     func userNotificationCenter(

--- a/UhooiPicBook/AppDelegate.swift
+++ b/UhooiPicBook/AppDelegate.swift
@@ -23,7 +23,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         #endif
 
         FirebaseApp.configure()
-        configurePushNotifications(application: application)
+        configureNotifications(application: application)
         Messaging.messaging().delegate = self
 
         return true
@@ -45,13 +45,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     // MARK: Other Private Methods
 
-    private func configurePushNotifications(application: UIApplication) {
-        UNUserNotificationCenter.current().delegate = self
-        let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
-        UNUserNotificationCenter.current().requestAuthorization(
-            options: authOptions
-        ) {_, _ in
-        }
+    private func configureNotifications(application: UIApplication) {
+        let center = UNUserNotificationCenter.current()
+        center.delegate = self
+        center.requestAuthorization(
+            options: [.alert, .badge, .sound]
+        ) { _, _ in }
+
         application.registerForRemoteNotifications()
     }
 

--- a/UhooiPicBook/SceneDelegate.swift
+++ b/UhooiPicBook/SceneDelegate.swift
@@ -51,6 +51,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneWillEnterForeground(_ scene: UIScene) {
         // Called as the scene transitions from the background to the foreground.
         // Use this method to undo the changes made on entering the background.
+        UIApplication.shared.applicationIconBadgeNumber = 0
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {

--- a/UhooiPicBook/UhooiPicBook.entitlements
+++ b/UhooiPicBook/UhooiPicBook.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/project.yml
+++ b/project.yml
@@ -31,6 +31,7 @@ targets:
         CURRENT_PROJECT_VERSION: 9
         DEVELOPMENT_TEAM: 47E56DYP3N
         INFOPLIST_FILE: UhooiPicBook/Info.plist
+        CODE_SIGN_ENTITLEMENTS: UhooiPicBook/UhooiPicBook.entitlements
         OTHER_LDFLAGS: $(inherited) $(OTHER_LDFLAGS) -ObjC
         DEVELOPMENT_LANGUAGE: jp
     dependencies:

--- a/project.yml
+++ b/project.yml
@@ -64,6 +64,8 @@ targets:
         embed: false
       - framework: Carthage/Build/iOS/FirebaseInstallations.framework
         embed: false
+      - framework: Carthage/Build/iOS/FirebaseMessaging.framework
+        embed: false
       - framework: Carthage/Build/iOS/FirebasePerformance.framework
         embed: false
       - framework: Carthage/Build/iOS/FirebaseRemoteConfig.framework

--- a/project.yml
+++ b/project.yml
@@ -61,6 +61,8 @@ targets:
         embed: false
       - framework: Carthage/Build/iOS/FirebaseInstallations.framework
         embed: false
+      - framework: Carthage/Build/iOS/FirebaseInstanceID.framework
+        embed: false
       - framework: Carthage/Build/iOS/FirebaseMessaging.framework
         embed: false
       - framework: Carthage/Build/iOS/FirebasePerformance.framework

--- a/project.yml
+++ b/project.yml
@@ -41,9 +41,6 @@ targets:
         buildPhase:
           copyFiles:
             destination: plugins
-      - framework: Carthage/Build/iOS/Firebase.framework
-        embed: false
-        link: false
       - framework: Carthage/Build/iOS/abseil.framework
         embed: false
       - framework: Carthage/Build/iOS/BoringSSL-GRPC.framework

--- a/spell-checker.yml
+++ b/spell-checker.yml
@@ -8,6 +8,7 @@ whiteList:
   - swiftlint
   - gedatsu
   - json
+  - fcm
 
   # Uhooi
   - theuhooi


### PR DESCRIPTION
## 要求仕様

- お知らせ（新モンスターの追加など）をリモートプッシュ通知でユーザーへ伝えたい
  - 開封時は特に何もせず、アプリが起動するのみでいい
  - バッジはバックグラウンド時のみ付け、フォアグラウンド復帰時に外す

## 要件

- 無料で実現する
- できる限りシンプルに実現する

## 実現方法

Firebase Cloud Messaging（以下「FCM」）を使って実現する。

1. 【ユーザー】アプリを起動し、通知を許可する
2. 【ウホーイ】FirebaseのコンソールからFCMの通知を送る
3. 【ユーザー】通知を受け取り、バックグラウンド時にはバッジが付く
4. 【ユーザー】通知またはホーム画面からアプリを起動し、バッジが外れる

## イシュー

- close #54