### PR TITLE
初回表示で画像のキャッシュが残ってセルがチラつくことがある

### DIFF
--- a/UhooiPicBook/Modules/MonsterList/Views/MonsterCollectionViewCell.swift
+++ b/UhooiPicBook/Modules/MonsterList/Views/MonsterCollectionViewCell.swift
@@ -30,6 +30,7 @@ final class MonsterCollectionViewCell: UICollectionViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         self.iconImageView.image = nil
+        self.nameLabel.text = nil
     }
 
     // MARK: Other Internal Methods

--- a/UhooiPicBook/Modules/MonsterList/Views/MonsterCollectionViewCell.swift
+++ b/UhooiPicBook/Modules/MonsterList/Views/MonsterCollectionViewCell.swift
@@ -26,6 +26,13 @@ final class MonsterCollectionViewCell: UICollectionViewCell {
             newValue.text = nil
         }
     }
+    
+    // MARK: View Life-Cycle Methods
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        iconImageView.image = nil
+    }
 
     // MARK: Other Internal Methods
 

--- a/UhooiPicBook/Modules/MonsterList/Views/MonsterCollectionViewCell.swift
+++ b/UhooiPicBook/Modules/MonsterList/Views/MonsterCollectionViewCell.swift
@@ -26,12 +26,10 @@ final class MonsterCollectionViewCell: UICollectionViewCell {
             newValue.text = nil
         }
     }
-    
     // MARK: View Life-Cycle Methods
-    
     override func prepareForReuse() {
         super.prepareForReuse()
-        iconImageView.image = nil
+        self.iconImageView.image = nil
     }
 
     // MARK: Other Internal Methods


### PR DESCRIPTION
PR投げときます笑

１回表示されると画像がキャッシュされて高速化されるので再現できない、ので再インストールして高速スクロールするとみれるはず〜