### PR TITLE
Add [weak self]

### DIFF
--- a/UhooiPicBook/Modules/MonsterDetail/Presenters/MonsterDetailPresenter.swift
+++ b/UhooiPicBook/Modules/MonsterDetail/Presenters/MonsterDetailPresenter.swift
@@ -55,7 +55,11 @@ extension MonsterDetailPresenter: MonsterDetailEventHandler {
     }
 
     func didTapShareButton(_ senderView: UIView?, name: String?, description: String?, icon: UIImage?) {
-        guard let senderView = senderView, let name = name, let description = description, let icon = icon else {
+        guard let senderView = senderView,
+              let name = name,
+              let description = description,
+              let icon = icon
+        else {
             return // TODO: エラーハンドリング
         }
         let text = "\(name)\n\(description)\n\(R.string.localizable.uhooiPicBookHashtag())"

--- a/UhooiPicBook/Modules/MonsterDetail/Views/MonsterDetailViewController.swift
+++ b/UhooiPicBook/Modules/MonsterDetail/Views/MonsterDetailViewController.swift
@@ -61,8 +61,12 @@ final class MonsterDetailViewController: UIViewController {
     // MARK: IBActions
 
     @IBAction private func didTapShareButton(_ sender: UIBarButtonItem) {
-        self.presenter.didTapShareButton(sender.value(forKey: "view") as? UIView, name: self.nameLabel.text, description: self.descriptionLabel.text,
-                                         icon: self.iconImageView.image)
+        self.presenter.didTapShareButton(
+            sender.value(forKey: "view") as? UIView,
+            name: self.nameLabel.text,
+            description: self.descriptionLabel.text,
+            icon: self.iconImageView.image
+        )
     }
 
     // MARK: Other Private Methods
@@ -73,11 +77,11 @@ final class MonsterDetailViewController: UIViewController {
     }
 
     private func configureView() {
-        self.imageCacheManager.cacheImage(imageUrl: monster.iconUrl) { result in
+        self.imageCacheManager.cacheImage(imageUrl: monster.iconUrl) { [weak self] result in
             switch result {
             case let .success(icon):
                 DispatchQueue.main.async {
-                    self.iconImageView.image = icon
+                    self?.iconImageView.image = icon
                 }
             case let .failure(error):
                 // TODO: エラーハンドリング

--- a/UhooiPicBook/Modules/MonsterDetail/Views/MonsterDetailViewController.swift
+++ b/UhooiPicBook/Modules/MonsterDetail/Views/MonsterDetailViewController.swift
@@ -80,7 +80,7 @@ final class MonsterDetailViewController: UIViewController {
         self.imageCacheManager.cacheImage(imageUrl: monster.iconUrl) { [weak self] result in
             switch result {
             case let .success(icon):
-                DispatchQueue.main.async {
+                DispatchQueue.main.async { [weak self] in
                     self?.iconImageView.image = icon
                 }
             case let .failure(error):

--- a/UhooiPicBook/Modules/MonsterList/Presenters/MonsterListPresenter.swift
+++ b/UhooiPicBook/Modules/MonsterList/Presenters/MonsterListPresenter.swift
@@ -51,17 +51,17 @@ extension MonsterListPresenter: MonsterListEventHandler {
 
     func viewDidLoad() {
         self.view.startIndicator()
-        self.interactor.fetchMonsters { result in
+        self.interactor.fetchMonsters { [weak self] result in
             switch result {
             case let .success(monsters):
                 let monsterEntities = monsters
                     .sorted { $0.order < $1.order }
-                    .map { self.convertDTOToEntity(dto: $0) }
-                self.view.showMonsters(monsterEntities)
-                self.view.stopIndicator()
+                    .compactMap { self?.convertDTOToEntity(dto: $0) }
+                self?.view.showMonsters(monsterEntities)
+                self?.view.stopIndicator()
             case let .failure(error):
                 // TODO: エラーハンドリング
-                self.view.stopIndicator()
+                self?.view.stopIndicator()
             }
         }
     }

--- a/UhooiPicBook/Modules/MonsterList/Presenters/MonsterListPresenter.swift
+++ b/UhooiPicBook/Modules/MonsterList/Presenters/MonsterListPresenter.swift
@@ -52,16 +52,19 @@ extension MonsterListPresenter: MonsterListEventHandler {
     func viewDidLoad() {
         self.view.startIndicator()
         self.interactor.fetchMonsters { [weak self] result in
+            guard let self = self else {
+                return
+            }
             switch result {
             case let .success(monsters):
                 let monsterEntities = monsters
                     .sorted { $0.order < $1.order }
-                    .compactMap { self?.convertDTOToEntity(dto: $0) }
-                self?.view.showMonsters(monsterEntities)
-                self?.view.stopIndicator()
+                    .map { self.convertDTOToEntity(dto: $0) }
+                self.view.showMonsters(monsterEntities)
+                self.view.stopIndicator()
             case let .failure(error):
                 // TODO: エラーハンドリング
-                self?.view.stopIndicator()
+                self.view.stopIndicator()
             }
         }
     }

--- a/UhooiPicBook/Modules/MonsterList/Views/MonsterListViewController.swift
+++ b/UhooiPicBook/Modules/MonsterList/Views/MonsterListViewController.swift
@@ -35,17 +35,17 @@ final class MonsterListViewController: UIViewController {
             newValue.menu = UIMenu(
                 title: "",
                 children: [
-                    UIAction(title: R.string.localizable.contactUs()) { _ in
-                        self.presenter.didTapContactUs()
+                    UIAction(title: R.string.localizable.contactUs()) { [weak self] _ in
+                        self?.presenter.didTapContactUs()
                     },
-                    UIAction(title: R.string.localizable.privacyPolicy()) { _ in
-                        self.presenter.didTapPrivacyPolicy()
+                    UIAction(title: R.string.localizable.privacyPolicy()) { [weak self] _ in
+                        self?.presenter.didTapPrivacyPolicy()
                     },
-                    UIAction(title: R.string.localizable.licenses()) { _ in
-                        self.presenter.didTapLicenses()
+                    UIAction(title: R.string.localizable.licenses()) { [weak self] _ in
+                        self?.presenter.didTapLicenses()
                     },
-                    UIAction(title: R.string.localizable.aboutThisApp()) { _ in
-                        self.presenter.didTapAboutThisApp()
+                    UIAction(title: R.string.localizable.aboutThisApp()) { [weak self] _ in
+                        self?.presenter.didTapAboutThisApp()
                     }
                 ]
             )

--- a/UhooiPicBook/Repository/Spotlight/SpotlightRepository.swift
+++ b/UhooiPicBook/Repository/Spotlight/SpotlightRepository.swift
@@ -31,9 +31,10 @@ final class SpotlightClient {
 extension SpotlightClient: SpotlightRepository {
 
     func saveMonster(_ monster: MonsterEntity, forKey key: String) {
-        self.imageCacheManager.cacheImage(imageUrl: monster.iconUrl) { result in
+        self.imageCacheManager.cacheImage(imageUrl: monster.iconUrl) { [weak self] result in
             switch result {
             case .success(let image):
+                guard let self = self else { return }
                 let thumbnailData = image.resize(CGSize(width: 180.0, height: 180.0))?.pngData()
                 let item = CSSearchableItem(
                     uniqueIdentifier: key,

--- a/UhooiPicBook/Repository/Spotlight/SpotlightRepository.swift
+++ b/UhooiPicBook/Repository/Spotlight/SpotlightRepository.swift
@@ -32,9 +32,11 @@ extension SpotlightClient: SpotlightRepository {
 
     func saveMonster(_ monster: MonsterEntity, forKey key: String) {
         self.imageCacheManager.cacheImage(imageUrl: monster.iconUrl) { [weak self] result in
+            guard let self = self else {
+                return
+            }
             switch result {
             case .success(let image):
-                guard let self = self else { return }
                 let thumbnailData = image.resize(CGSize(width: 180.0, height: 180.0))?.pngData()
                 let item = CSSearchableItem(
                     uniqueIdentifier: key,

--- a/UhooiPicBook/UIParts/InAppWebBrowser/InAppWebBrowserViewController.swift
+++ b/UhooiPicBook/UIParts/InAppWebBrowser/InAppWebBrowserViewController.swift
@@ -55,23 +55,26 @@ final class InAppWebBrowserViewController: UIViewController {
 
     private func observeWebView() {
         self.estimatedProgressObservation = self.webView.observe(\.estimatedProgress, options: [.new]) { [weak self] webView, _ in
+            guard let self = self else {
+                return
+            }
             // swiftlint:disable:next trailing_closure
             UIView.animate(
                 withDuration: 0.33,
                 animations: {
-                    self?.progressView.alpha = 1.0
+                    self.progressView.alpha = 1.0
                 }
             )
-            self?.progressView.setProgress(Float(webView.estimatedProgress), animated: true)
+            self.progressView.setProgress(Float(webView.estimatedProgress), animated: true)
 
             if webView.estimatedProgress >= 1.0 {
                 UIView.animate(
                     withDuration: 0.33,
                     animations: {
-                        self?.progressView.alpha = 0.0
+                        self.progressView.alpha = 0.0
                     },
                     completion: { _ in
-                        self?.progressView.setProgress(0.0, animated: false)
+                        self.progressView.setProgress(0.0, animated: false)
                     }
                 )
             }

--- a/UhooiPicBook/UIParts/InAppWebBrowser/InAppWebBrowserViewController.swift
+++ b/UhooiPicBook/UIParts/InAppWebBrowser/InAppWebBrowserViewController.swift
@@ -54,24 +54,24 @@ final class InAppWebBrowserViewController: UIViewController {
     }
 
     private func observeWebView() {
-        self.estimatedProgressObservation = self.webView.observe(\.estimatedProgress, options: [.new]) { webView, _ in
+        self.estimatedProgressObservation = self.webView.observe(\.estimatedProgress, options: [.new]) { [weak self] webView, _ in
             // swiftlint:disable:next trailing_closure
             UIView.animate(
                 withDuration: 0.33,
                 animations: {
-                    self.progressView.alpha = 1.0
+                    self?.progressView.alpha = 1.0
                 }
             )
-            self.progressView.setProgress(Float(webView.estimatedProgress), animated: true)
+            self?.progressView.setProgress(Float(webView.estimatedProgress), animated: true)
 
             if webView.estimatedProgress >= 1.0 {
                 UIView.animate(
                     withDuration: 0.33,
                     animations: {
-                        self.progressView.alpha = 0.0
+                        self?.progressView.alpha = 0.0
                     },
                     completion: { _ in
-                        self.progressView.setProgress(0.0, animated: false)
+                        self?.progressView.setProgress(0.0, animated: false)
                     }
                 )
             }

--- a/UhooiPicBook/UIParts/InAppWebBrowser/InAppWebBrowserViewController.swift
+++ b/UhooiPicBook/UIParts/InAppWebBrowser/InAppWebBrowserViewController.swift
@@ -58,25 +58,17 @@ final class InAppWebBrowserViewController: UIViewController {
             guard let self = self else {
                 return
             }
-            // swiftlint:disable:next trailing_closure
-            UIView.animate(
-                withDuration: 0.33,
-                animations: {
-                    self.progressView.alpha = 1.0
-                }
-            )
+            UIView.animate(withDuration: 0.33) {
+                self.progressView.alpha = 1.0
+            }
             self.progressView.setProgress(Float(webView.estimatedProgress), animated: true)
 
             if webView.estimatedProgress >= 1.0 {
-                UIView.animate(
-                    withDuration: 0.33,
-                    animations: {
-                        self.progressView.alpha = 0.0
-                    },
-                    completion: { _ in
-                        self.progressView.setProgress(0.0, animated: false)
-                    }
-                )
+                UIView.animate(withDuration: 0.33) {
+                    self.progressView.alpha = 0.0
+                } completion: { _ in
+                    self.progressView.setProgress(0.0, animated: false)
+                }
             }
         }
     }


### PR DESCRIPTION
## Overview

クロージャで循環参照によるメモリリークが発生し得る（escaping していて `self` を使っている）箇所に `[weak self]` を追加した。

`self` のアンラップ方針として、 `self` が `nil` のときは異常系なので基本的には `guard let self = self else { return }` で最初に早期リターンするようにした。
しかし行数が増えるので、スッキリ書きたい場合はオプショナルチェインニングを使って `self?.○○` と書くようにした。

## References

- https://twitter.com/yskmanabe/status/1463570990420541440?s=20  
    ```
    guard let self = self  else {
        return
    }
    ↑純正常、異常系は早期リターン
    ---------
    ↓正常系
    ```
- https://twitter.com/griffin_stewie/status/1463516139330306057?s=20  
    > 僕の好みは、self? だと 「nil じゃないつもりでしたが、nil なこともあったのね」って感じで想定外が存在することを知りたい時は、アンラップして、else 節にログなり preconditionFailure を書いたりする。本当に呼ばれなくても困らない状況なら self? で楽をする。