### PR TITLE
Bump CLI tools

### DIFF
--- a/Sources/AppModule/Modules/MonsterDetail/Interactors/MonsterDetailInteractor.swift
+++ b/Sources/AppModule/Modules/MonsterDetail/Interactors/MonsterDetailInteractor.swift
@@ -20,7 +20,7 @@ final class MonsterDetailInteractor {
 
     init() {
     }
-    
+
     // MARK: Other Internal Methods
 
     func inject(presenter: MonsterDetailInteractorOutput) {

--- a/Sources/AppModule/Modules/MonsterList/Interactors/MonsterListInteractor.swift
+++ b/Sources/AppModule/Modules/MonsterList/Interactors/MonsterListInteractor.swift
@@ -35,7 +35,7 @@ final class MonsterListInteractor {
         self.monstersRepository = monstersRepository
         self.monstersTempRepository = monstersTempRepository
     }
-    
+
     // MARK: Other Internal Methods
 
     func inject(presenter: MonsterListInteractorOutput) {

--- a/Tools/UhooiPicBookTools/Package.resolved
+++ b/Tools/UhooiPicBookTools/Package.resolved
@@ -192,11 +192,11 @@
       },
       {
         "package": "xcbeautify",
-        "repositoryURL": "https://github.com/thii/xcbeautify",
+        "repositoryURL": "https://github.com/tuist/xcbeautify",
         "state": {
           "branch": null,
-          "revision": "6e24f64e068f31d4514335e66b2804e02f3480a6",
-          "version": "0.10.1"
+          "revision": "b14660cc03d96889d2144265fbca471ea0076e40",
+          "version": "0.11.0"
         }
       },
       {
@@ -206,6 +206,15 @@
           "branch": null,
           "revision": "1fc861d368831f751341f804298e78ebb789592e",
           "version": "2.2.0"
+        }
+      },
+      {
+        "package": "XMLCoder",
+        "repositoryURL": "https://github.com/MaxDesiatov/XMLCoder.git",
+        "state": {
+          "branch": null,
+          "revision": "f30119af03996939cc4f54e0bf0dda9f88a84da5",
+          "version": "0.13.1"
         }
       },
       {

--- a/Tools/UhooiPicBookTools/Package.resolved
+++ b/Tools/UhooiPicBookTools/Package.resolved
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/uber/mockolo",
         "state": {
           "branch": null,
-          "revision": "f9110ced9267927600e415034499ae0e63d47f7b",
-          "version": "1.6.2"
+          "revision": "61d4fb9c10eacf78b63c9473ce792b2772c0ad0d",
+          "version": "1.6.3"
         }
       },
       {

--- a/Tools/UhooiPicBookTools/Package.resolved
+++ b/Tools/UhooiPicBookTools/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/mono0926/LicensePlist",
         "state": {
           "branch": null,
-          "revision": "22d5de3a45008f5c366bea25e5279e49d3a3f3fd",
-          "version": "3.14.4"
+          "revision": "3d365e4ab943774171a75d64da9a71bb2ff7dfa2",
+          "version": "3.17.0"
         }
       },
       {

--- a/Tools/UhooiPicBookTools/Package.swift
+++ b/Tools/UhooiPicBookTools/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .package(url: "https://github.com/realm/SwiftLint", .exact("0.45.0")),
         .package(url: "https://github.com/IBDecodable/IBLinter", .exact("0.4.27")),
         .package(url: "https://github.com/fromkk/SpellChecker", .exact("0.1.0")),
-        .package(url: "https://github.com/uber/mockolo", .exact("1.6.2")),
+        .package(url: "https://github.com/uber/mockolo", .exact("1.6.3")),
         .package(url: "https://github.com/mono0926/LicensePlist", .exact("3.17.0")),
         .package(url: "https://github.com/tuist/xcbeautify", .exact("0.11.0")),
     ],

--- a/Tools/UhooiPicBookTools/Package.swift
+++ b/Tools/UhooiPicBookTools/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .package(url: "https://github.com/IBDecodable/IBLinter", .exact("0.4.27")),
         .package(url: "https://github.com/fromkk/SpellChecker", .exact("0.1.0")),
         .package(url: "https://github.com/uber/mockolo", .exact("1.6.2")),
-        .package(url: "https://github.com/mono0926/LicensePlist", .exact("3.14.4")),
+        .package(url: "https://github.com/mono0926/LicensePlist", .exact("3.17.0")),
         .package(url: "https://github.com/tuist/xcbeautify", .exact("0.11.0")),
     ],
     targets: [.target(name: "UhooiPicBookTools", path: "")]

--- a/Tools/UhooiPicBookTools/Package.swift
+++ b/Tools/UhooiPicBookTools/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .package(url: "https://github.com/fromkk/SpellChecker", .exact("0.1.0")),
         .package(url: "https://github.com/uber/mockolo", .exact("1.6.2")),
         .package(url: "https://github.com/mono0926/LicensePlist", .exact("3.14.4")),
-        .package(url: "https://github.com/thii/xcbeautify", .exact("0.10.1")),
+        .package(url: "https://github.com/tuist/xcbeautify", .exact("0.11.0")),
     ],
     targets: [.target(name: "UhooiPicBookTools", path: "")]
 )

--- a/UhooiPicBook.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/UhooiPicBook.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -192,11 +192,11 @@
       },
       {
         "package": "xcbeautify",
-        "repositoryURL": "https://github.com/thii/xcbeautify",
+        "repositoryURL": "https://github.com/tuist/xcbeautify",
         "state": {
           "branch": null,
-          "revision": "6e24f64e068f31d4514335e66b2804e02f3480a6",
-          "version": "0.10.1"
+          "revision": "b14660cc03d96889d2144265fbca471ea0076e40",
+          "version": "0.11.0"
         }
       },
       {
@@ -206,6 +206,15 @@
           "branch": null,
           "revision": "680db38d06462f9242a789d529a3e2a75c882365",
           "version": "2.3.0"
+        }
+      },
+      {
+        "package": "XMLCoder",
+        "repositoryURL": "https://github.com/MaxDesiatov/XMLCoder.git",
+        "state": {
+          "branch": null,
+          "revision": "f30119af03996939cc4f54e0bf0dda9f88a84da5",
+          "version": "0.13.1"
         }
       },
       {

--- a/UhooiPicBook.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/UhooiPicBook.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/uber/mockolo",
         "state": {
           "branch": null,
-          "revision": "f9110ced9267927600e415034499ae0e63d47f7b",
-          "version": "1.6.2"
+          "revision": "61d4fb9c10eacf78b63c9473ce792b2772c0ad0d",
+          "version": "1.6.3"
         }
       },
       {

--- a/UhooiPicBook.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/UhooiPicBook.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/mono0926/LicensePlist",
         "state": {
           "branch": null,
-          "revision": "22d5de3a45008f5c366bea25e5279e49d3a3f3fd",
-          "version": "3.14.4"
+          "revision": "3d365e4ab943774171a75d64da9a71bb2ff7dfa2",
+          "version": "3.17.0"
         }
       },
       {


### PR DESCRIPTION
## Details

- Bump xcbeautify from `0.10.1` to `0.11.0`
- Bump LicensePlist from `3.14.4` to `3.17.0`
- Bump Mockolo from `1.6.2` to `1.6.3`

## Checklist

- [x] Format code with SwiftLint (<kbd>⌘B</kbd> in Xcode)
- [x] Resolve Xcode warning

## References

- https://github.com/tuist/xcbeautify/releases
- https://github.com/mono0926/LicensePlist/releases
- https://github.com/uber/mockolo/releases/tag/1.6.3