### PR TITLE
Bump LicensePlist from 3.17.0 to 3.19.1

### DIFF
--- a/Tools/UhooiPicBookTools/Package.resolved
+++ b/Tools/UhooiPicBookTools/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/mono0926/LicensePlist",
         "state": {
           "branch": null,
-          "revision": "3d365e4ab943774171a75d64da9a71bb2ff7dfa2",
-          "version": "3.17.0"
+          "revision": "b6929adffb31749a9930fdb295f79e4027a18e25",
+          "version": "3.19.1"
         }
       },
       {

--- a/Tools/UhooiPicBookTools/Package.swift
+++ b/Tools/UhooiPicBookTools/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .package(url: "https://github.com/IBDecodable/IBLinter", .exact("0.5.0")),
         .package(url: "https://github.com/fromkk/SpellChecker", .exact("0.1.0")),
         .package(url: "https://github.com/uber/mockolo", .exact("1.6.3")),
-        .package(url: "https://github.com/mono0926/LicensePlist", .exact("3.17.0")),
+        .package(url: "https://github.com/mono0926/LicensePlist", .exact("3.19.1")),
         .package(url: "https://github.com/tuist/xcbeautify", .exact("0.11.0")),
     ],
     targets: [.target(name: "UhooiPicBookTools", path: "")]

--- a/UhooiPicBook.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/UhooiPicBook.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/mono0926/LicensePlist",
         "state": {
           "branch": null,
-          "revision": "3d365e4ab943774171a75d64da9a71bb2ff7dfa2",
-          "version": "3.17.0"
+          "revision": "b6929adffb31749a9930fdb295f79e4027a18e25",
+          "version": "3.19.1"
         }
       },
       {


### PR DESCRIPTION
## Reference

- https://github.com/mono0926/LicensePlist/releases
