### PR TITLE
Bump LicensePlist from 3.19.1 to 3.23.4

### DIFF
--- a/Mintfile
+++ b/Mintfile
@@ -2,5 +2,5 @@ realm/SwiftLint@0.49.1
 IBDecodable/IBLinter@0.5.0
 fromkk/SpellChecker@0.1.0
 uber/mockolo@1.8.0
-mono0926/LicensePlist@3.19.1
+mono0926/LicensePlist@3.23.4
 tuist/xcbeautify@0.11.0


### PR DESCRIPTION
## Issue

- close #336

## Reference

- https://github.com/mono0926/LicensePlist/releases