### PR TITLE
CI の artifact action を v4 に更新

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: failure()
       with:
-        name: xcodebuild-logs
+        name: xcodebuild-logs-${{ matrix.environment }}
         path: |
           Reports/*_Build.log
         if-no-files-found: ignore
@@ -87,7 +87,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
-        name: test-results
+        name: test-results-${{ matrix.name }}
         path: |
           Reports/*.xcresult
         if-no-files-found: error
@@ -98,7 +98,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: failure()
       with:
-        name: xcodebuild-logs
+        name: xcodebuild-logs-${{ matrix.name }}
         path: |
           Reports/*_Test.log
         if-no-files-found: ignore
@@ -118,8 +118,9 @@ jobs:
     - name: Download test results artifact
       uses: actions/download-artifact@v4
       with:
-        name: test-results
+        pattern: test-results-*
         path: Reports
+        merge-multiple: true
 
     # テスト結果のマージ
     - name: Merge test results

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,6 +131,7 @@ jobs:
       if: success() || failure()
       with:
         path: Reports/TestResults.xcresult
+        upload-bundles: never
 
   info:
     runs-on: macos-14

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
 
     # ビルドログのアップロード
     - name: Upload build log Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: xcodebuild-logs
@@ -84,7 +84,7 @@ jobs:
 
     # テスト結果のアップロード
     - name: Upload test results Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
         name: test-results
@@ -95,7 +95,7 @@ jobs:
 
     # 単体テストログのアップロード
     - name: Upload test log Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: xcodebuild-logs
@@ -116,7 +116,7 @@ jobs:
 
     # テスト結果のダウンロード
     - name: Download test results artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: test-results
         path: Reports
@@ -140,4 +140,3 @@ jobs:
 
     # 情報の出力
     - uses: ./.github/workflows/templates/output-info
-


### PR DESCRIPTION
## やったこと

- CI ワークフローで使用している artifact action を v4 に更新した
- 廃止済みの actions/upload-artifact@v3 と actions/download-artifact@v3 を置き換えた

## やってないこと

- なし

## 参考リンク

- https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/